### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 MyEnvironmentConfig
 ===================
 
-Helper classes that map configuration values to XCode build configurations. 
+Helper classes that map configuration values to Xcode build configurations. 
 
 ## Installation
 


### PR DESCRIPTION
This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
